### PR TITLE
feat: add profile, cookie, and locale controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "dirs",
  "headless_chrome",
  "reqwest 0.11.27",
  "serde",
@@ -822,6 +823,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2174,6 +2196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2560,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.3",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ua_generator = "0.5"
+dirs = "5"
 
 # HTTP client for the fast path
 reqwest = { version = "0.11", features = ["gzip", "brotli", "deflate", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ Disable PDF (just JSON/Screenshot):
 ```bash
 ./ankabot --no-pdf --screenshot yahoo.png https://yahoo.com
 ```
+
+### Stateful profiles, cookies, and locale emulation
+
+```bash
+./ankabot https://yahoo.com \
+  --profile yahoo-eu \
+  --locale ru-RU --tz Europe/Moscow --geo "55.7558,37.6173" \
+  --import-cookies cookies/yahoo.json \
+  --export-cookies out/yahoo.cookies.json \
+  --pdf out/yahoo.pdf
+```


### PR DESCRIPTION
## Summary
- add persistent Chrome profiles with optional proxy/extension flags
- support cookie import/export and locale/timezone/geolocation overrides
- document new CLI usage

## Testing
- `cargo test` *(fails: Could not auto detect a chrome executable)*

------
https://chatgpt.com/codex/tasks/task_e_68aee206a14c832d9c3116f0a0d12959